### PR TITLE
feat(theme): add `catppuccin`

### DIFF
--- a/css/community-theme-options/catppuccin-frappe.css
+++ b/css/community-theme-options/catppuccin-frappe.css
@@ -1,0 +1,34 @@
+:root {
+  --main-bg-color: #303446;
+
+  --modal-bg-color: #292c3c;
+  --modal-header-color: #232634;
+  --modal-footer-color: #232634;
+
+  --drop-down-menu-bg: #414559;
+
+  --button-color: #414559;
+  --button-color-hover: #51576d;
+  --button-text: var(--text);
+  --button-text-hover: var(--text-hover);
+
+  --accent-color: 137, 180, 250; /* Mocha Blue */
+  --accent-color-hover: rgb(var(--accent-color), 0.8);
+  --link-color: var(--text);
+  --link-color-hover: #8caaee;
+  --label-text-color: #fff; /* have to break convention here */
+
+  --text: #c6d0f5;
+  --text-hover: var(--text);
+  --text-muted: a5adce;
+
+  /* Specials */
+  --arr-queue-color: #a6d189; /* Servarr apps + Bazarr */
+  --plex-poster-unwatched: #ef9f76;
+  --petio-spinner: invert(66%) sepia(15%) saturate(1451%) hue-rotate(185deg) brightness(105%) contrast(96%); /* Made with https://codepen.io/jsm91/embed/ZEEawyZ */ /* Blue */
+  --gitea-color-primary-dark-4: var(--accent-color);
+  --overseerr-gradient: linear-gradient(
+    var(--main-bg-color),
+    var(--main-bg-color)
+  ); /* Make sure this is compatible with whatever takes in the gradient */
+}

--- a/css/community-theme-options/catppuccin-latte.css
+++ b/css/community-theme-options/catppuccin-latte.css
@@ -1,0 +1,34 @@
+:root {
+  --main-bg-color: #eff1f5;
+
+  --modal-bg-color: #e6e9ef;
+  --modal-header-color: #dce0e8;
+  --modal-footer-color: #dce0e8;
+
+  --drop-down-menu-bg: #ccd0da;
+
+  --button-color: #ccd0da;
+  --button-color-hover: #bcc0cc;
+  --button-text: var(--text);
+  --button-text-hover: var(--text-hover);
+
+  --accent-color: 137, 180, 250; /* Mocha Blue */
+  --accent-color-hover: rgb(var(--accent-color), 0.8);
+  --link-color: var(--text);
+  --link-color-hover: #1e66f5;
+  --label-text-color: #fff; /* have to break convention here */
+
+  --text: #4c4f69;
+  --text-hover: var(--text);
+  --text-muted: 6c6f85;
+
+  /* Specials */
+  --arr-queue-color: #40a02b; /* Servarr apps + Bazarr */
+  --plex-poster-unwatched: #fe640b;
+  --petio-spinner: invert(66%) sepia(15%) saturate(1451%) hue-rotate(185deg) brightness(105%) contrast(96%); /* Made with https://codepen.io/jsm91/embed/ZEEawyZ */ /* Blue */
+  --gitea-color-primary-dark-4: var(--accent-color);
+  --overseerr-gradient: linear-gradient(
+    var(--main-bg-color),
+    var(--main-bg-color)
+  ); /* Make sure this is compatible with whatever takes in the gradient */
+}

--- a/css/community-theme-options/catppuccin-macchiato.css
+++ b/css/community-theme-options/catppuccin-macchiato.css
@@ -1,0 +1,34 @@
+:root {
+  --main-bg-color: #24273a;
+
+  --modal-bg-color: #1e2030;
+  --modal-header-color: #181926;
+  --modal-footer-color: #181926;
+
+  --drop-down-menu-bg: #363a4f;
+
+  --button-color: #363a4f;
+  --button-color-hover: #494d64;
+  --button-text: var(--text);
+  --button-text-hover: var(--text-hover);
+
+  --accent-color: 137, 180, 250; /* Mocha Blue */
+  --accent-color-hover: rgb(var(--accent-color), 0.8);
+  --link-color: var(--text);
+  --link-color-hover: #8aadf4;
+  --label-text-color: #fff; /* have to break convention here */
+
+  --text: #cad3f5;
+  --text-hover: var(--text);
+  --text-muted: a5adcb;
+
+  /* Specials */
+  --arr-queue-color: #a6da95; /* Servarr apps + Bazarr */
+  --plex-poster-unwatched: #f5a97f;
+  --petio-spinner: invert(66%) sepia(15%) saturate(1451%) hue-rotate(185deg) brightness(105%) contrast(96%); /* Made with https://codepen.io/jsm91/embed/ZEEawyZ */ /* Blue */
+  --gitea-color-primary-dark-4: var(--accent-color);
+  --overseerr-gradient: linear-gradient(
+    var(--main-bg-color),
+    var(--main-bg-color)
+  ); /* Make sure this is compatible with whatever takes in the gradient */
+}

--- a/css/community-theme-options/catppuccin-mocha.css
+++ b/css/community-theme-options/catppuccin-mocha.css
@@ -1,0 +1,34 @@
+:root {
+  --main-bg-color: #1e1e2e;
+
+  --modal-bg-color: #181825;
+  --modal-header-color: #11111b;
+  --modal-footer-color: #11111b;
+
+  --drop-down-menu-bg: #313244;
+
+  --button-color: #313244;
+  --button-color-hover: #45475a;
+  --button-text: var(--text);
+  --button-text-hover: var(--text-hover);
+
+  --accent-color: 137, 180, 250; /* Mocha Blue */
+  --accent-color-hover: rgb(var(--accent-color), 0.8);
+  --link-color: var(--text);
+  --link-color-hover: #89b4fa;
+  --label-text-color: #fff; /* have to break convention here */
+
+  --text: #cdd6f4;
+  --text-hover: var(--text);
+  --text-muted: a6adc8;
+
+  /* Specials */
+  --arr-queue-color: #a6e3a1; /* Servarr apps + Bazarr */
+  --plex-poster-unwatched: #fab387;
+  --petio-spinner: invert(66%) sepia(15%) saturate(1451%) hue-rotate(185deg) brightness(105%) contrast(96%); /* Made with https://codepen.io/jsm91/embed/ZEEawyZ */ /* Blue */
+  --gitea-color-primary-dark-4: var(--accent-color);
+  --overseerr-gradient: linear-gradient(
+    var(--main-bg-color),
+    var(--main-bg-color)
+  ); /* Make sure this is compatible with whatever takes in the gradient */
+}


### PR DESCRIPTION
## Description

This PR adds the [Catppuccin](https://github.com/catppuccin/theme.park) themes into the `Community Themes` section.

## Screenshots

`Latte`
![image](https://github.com/themepark-dev/theme.park/assets/58985301/ed55889f-1b06-4e45-af26-505e51bb6d6b)

`Frappe`
![image](https://github.com/themepark-dev/theme.park/assets/58985301/0e6bade7-2fe1-4f1d-9f3e-6fd43bf9ae66)

`Macchiato`
![image](https://github.com/themepark-dev/theme.park/assets/58985301/08a2230e-77aa-4704-bedd-3ccb919ebc6c)

`Mocha`
![image](https://github.com/themepark-dev/theme.park/assets/58985301/204ed7eb-072c-4c81-9bff-fb24d1c9aa9c)

## Benefits of this PR

- A new community theme is available for people to use by default.
- The current [catppuccin/theme.park](https://github.com/catppuccin/theme.park) repository does not redistribute the base theme, and therefore cannot be easily used in Docker Mods. (https://github.com/catppuccin/theme.park/issues/1) Integrating Catppuccin here would easily allow Docker Mods support without forking/redistributing the files.

## Additional Comments

I understand that, preferably, 10 screenshots are needed for a new theme. Unfortunately, I do not use `theme.park` myself but I'm sure that either @lewisakura or @iDavide94 would be willing to provide more screenshots if requested.

Please let me know if I have missed any changes that should have been made!

Thank you for your time and consideration.

------------------------------

 - [x] I have read the [contributing](https://github.com/GilbN/theme.park/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications