### PR TITLE
1.16.2

### DIFF
--- a/css/base/bazarr/bazarr-base.css
+++ b/css/base/bazarr/bazarr-base.css
@@ -17,6 +17,10 @@ html {
 
 /* TEXT */
 
+.bazarr-Text-root {
+    color: var(--text);
+}
+
 [class$="-label"]:not([class$="-Button-label"]),
 label {
     color: var(--text-hover) !important;

--- a/css/base/prowlarr/prowlarr-base.css
+++ b/css/base/prowlarr/prowlarr-base.css
@@ -14,6 +14,10 @@
 @import url("/css/defaults/transparent.css");
 @import url("/css/defaults/servarr-base.css");
 
+:root {
+    --chartBackgroundColor: var(--transparency-dark-35) !important;
+    }
+
 [class*="IndexerSearchInput-sectionTitle-"] {
     color: var(--text-hover);
 }
@@ -62,14 +66,13 @@
     color: var(--text-hover);
 }
 
-/* ChartJS */
-[class*="Stats-fullWidthChart-"],
-[class*="Stats-halfWidthChart-"] {
-    background: var(--transparency-dark-25) !important;
+[class*="IndexerIndexTable-row-"]:hover {
+    background: var(--transparency-dark-10);
+    color: var(--text-hover);
 }
 
 canvas {
-    filter: invert(1)
+    text: white !important;
 }
 
 /* QUERY OPTIONS */

--- a/css/base/unraid/unraid-base.css
+++ b/css/base/unraid/unraid-base.css
@@ -675,7 +675,7 @@ div.shade-black {
 /* MODAL */
 
 .sweet-alert, .sweet-alert .sa-icon.sa-success .sa-fix {
-    background-color: var(--modal-bg-color);
+    background: var(--modal-bg-color);
 }
 
 .sweet-alert.nchan h2 {

--- a/css/defaults/servarr-base.css
+++ b/css/defaults/servarr-base.css
@@ -13,6 +13,12 @@
 @import url("/css/defaults/placeholders.css");
 @import url("/css/defaults/transparent.css");
 
+:root {
+    --scrollbarBackgroundColor: var(--transparency-light-25) !important;
+    --scrollbarHoverBackgroundColor: var(--transparency-light-35) !important;
+    --linkColor: var(--link-color) !important;
+    --linkHoverColor: var(--link-color-hover) !important;
+    }
 
 body {
     background: var(--main-bg-color);

--- a/docker-mods/qbittorrent/root/etc/s6-overlay/s6-rc.d/init-mod-themepark/run
+++ b/docker-mods/qbittorrent/root/etc/s6-overlay/s6-rc.d/init-mod-themepark/run
@@ -24,7 +24,7 @@ if [ "${TP_DISABLE_THEME}" = true ]; then
 fi
 
 if [ -z ${QBITTORRENT_VERSION+x} ]; then \
-    echo 'QBITTORRENT_VERSION not set. Using the latest stable.' \
+    echo 'QBITTORRENT_VERSION not set. Using the latest stable.'
     QBITTORRENT_VERSION=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp \
     && awk '/^P:qbittorrent-nox$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://' | sed 's/-.*//'); \
 fi

--- a/docker-mods/qbittorrent/root/etc/s6-overlay/s6-rc.d/init-mod-themepark/run
+++ b/docker-mods/qbittorrent/root/etc/s6-overlay/s6-rc.d/init-mod-themepark/run
@@ -23,6 +23,12 @@ if [ "${TP_DISABLE_THEME}" = true ]; then
   exit 0
 fi
 
+if [ -z ${QBITTORRENT_VERSION+x} ]; then \
+    echo 'QBITTORRENT_VERSION not set. Using the latest stable.' \
+    QBITTORRENT_VERSION=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/APKINDEX.tar.gz" | tar -xz -C /temp \
+    && awk '/^P:qbittorrent-nox$/,/V:/' /temp/APKINDEX | sed -n 2p | sed 's/^V://'); \
+fi
+
 # Display variables for troubleshooting 
 echo -e "Variables set:\\n\
 'APP_FILEPATH'=${APP_FILEPATH}\\n\
@@ -67,11 +73,9 @@ if [[ ! -d /themepark ]]; then
     echo '| Downloading WebUI files from github |'
     echo '---------------------------------------'
     printf '\nDownloading qBittorrent to /temp\n'
-    if [[ -n ${QBITTORRENT_VERSION} ]]; then
-        git clone --depth 1 -b release-${QBITTORRENT_VERSION} https://github.com/qbittorrent/qBittorrent /temp
-    else
-        git clone --depth 1 https://github.com/qbittorrent/qBittorrent /temp
-    fi
+    echo 'Downloading WebUI for version:' "${QBITTORRENT_VERSION}"
+    git clone --depth 1 -b release-${QBITTORRENT_VERSION} https://github.com/qbittorrent/qBittorrent /temp
+
     printf '\nDownload finished\n\n'
     cp -a /temp/src/webui/www /themepark
     cp -a /temp/src/icons/. /themepark/public/icons

--- a/docker-mods/qbittorrent/root/etc/s6-overlay/s6-rc.d/init-mod-themepark/run
+++ b/docker-mods/qbittorrent/root/etc/s6-overlay/s6-rc.d/init-mod-themepark/run
@@ -31,6 +31,7 @@ echo -e "Variables set:\\n\
 'TP_DOMAIN'=${TP_DOMAIN}\\n\
 'TP_COMMUNITY_THEME'=${TP_COMMUNITY_THEME}\\n\
 'TP_SCHEME'=${TP_SCHEME}\\n\
+'QBITTORRENT_VERSION'=${QBITTORRENT_VERSION}\\n\
 'TP_THEME'=${TP_THEME}\\n"
 
 # Set default
@@ -66,7 +67,11 @@ if [[ ! -d /themepark ]]; then
     echo '| Downloading WebUI files from github |'
     echo '---------------------------------------'
     printf '\nDownloading qBittorrent to /temp\n'
-    git clone --depth 1 https://github.com/qbittorrent/qBittorrent /temp
+    if [[ -n ${QBITTORRENT_VERSION} ]]; then
+        git clone --depth 1 release-${QBITTORRENT_VERSION} https://github.com/qbittorrent/qBittorrent /temp
+    else
+        git clone --depth 1 https://github.com/qbittorrent/qBittorrent /temp
+    fi
     printf '\nDownload finished\n\n'
     cp -a /temp/src/webui/www /themepark
     cp -a /temp/src/icons/. /themepark/public/icons

--- a/docker-mods/qbittorrent/root/etc/s6-overlay/s6-rc.d/init-mod-themepark/run
+++ b/docker-mods/qbittorrent/root/etc/s6-overlay/s6-rc.d/init-mod-themepark/run
@@ -25,8 +25,8 @@ fi
 
 if [ -z ${QBITTORRENT_VERSION+x} ]; then \
     echo 'QBITTORRENT_VERSION not set. Using the latest stable.' \
-    QBITTORRENT_VERSION=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/APKINDEX.tar.gz" | tar -xz -C /temp \
-    && awk '/^P:qbittorrent-nox$/,/V:/' /temp/APKINDEX | sed -n 2p | sed 's/^V://'); \
+    QBITTORRENT_VERSION=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp \
+    && awk '/^P:qbittorrent-nox$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://' | sed 's/-.*//'); \
 fi
 
 # Display variables for troubleshooting 
@@ -82,6 +82,7 @@ if [[ ! -d /themepark ]]; then
     cp -a /temp/src/icons/. /themepark/private/icons
     printf '\nCopy finished\n\n'
     rm -rf /temp
+    rm -rf /tmp/*
     printf '\nCleanup finished\n\n'
 fi
 

--- a/docker-mods/qbittorrent/root/etc/s6-overlay/s6-rc.d/init-mod-themepark/run
+++ b/docker-mods/qbittorrent/root/etc/s6-overlay/s6-rc.d/init-mod-themepark/run
@@ -68,7 +68,7 @@ if [[ ! -d /themepark ]]; then
     echo '---------------------------------------'
     printf '\nDownloading qBittorrent to /temp\n'
     if [[ -n ${QBITTORRENT_VERSION} ]]; then
-        git clone --depth 1 release-${QBITTORRENT_VERSION} https://github.com/qbittorrent/qBittorrent /temp
+        git clone --depth 1 -b release-${QBITTORRENT_VERSION} https://github.com/qbittorrent/qBittorrent /temp
     else
         git clone --depth 1 https://github.com/qbittorrent/qBittorrent /temp
     fi


### PR DESCRIPTION
## Fixes

- Add fix for qbittorrent dockermod downloading the wrong webui files. Default is now downloading the latest stable webui. Override by adding `QBITTORRENT_VERSION` e.g. `-e QBITTORRENT_VERSION=4.2.0`
- Some minor fixes on the servarr and prowlarr css.
- Some minor fixes on the bazarr css.
- Some minor fixes on the unraid css. 