### PR TITLE
fix qbittorrent unthemed elements

### DIFF
--- a/css/base/qbittorrent/qbittorrent-base.css
+++ b/css/base/qbittorrent/qbittorrent-base.css
@@ -519,6 +519,10 @@ fieldset {
 
 /*Modal */
 
+.mocha {
+    background: var(--drop-down-menu-bg);
+}
+
 .mochaOverlay {
   position: absolute;
   top: 0;
@@ -669,4 +673,13 @@ select:focus {
 #torrentsFilterToolbar {
   float: right;
   margin-right: .5rem;
+}
+
+#torrentsFilterInput {
+    background: var(--transparency-dark-25);
+    border: none;
+}
+
+label[for="torrentsFilterRegexBox"] {
+      border: none !important;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[themeparkurl]: https://theme-park.dev
[![theme-park.dev](https://raw.githubusercontent.com/GilbN/theme.park/master/banners/tp_banner.png)][themeparkurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality/styling please look at making an addon instead. https://docs.theme-park.dev/themes/addons/sonarr/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->

------------------------------

 - [x] I have read the [contributing](https://github.com/GilbN/theme.park/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

- PR's are done against the develop branch.
------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Bug fixes

- When submitting bugfixes please show a before and after screenshot of the fix, and a description of what the fix does.

## Description:
Hello, qbittorrent 5.0 introduced a few unthemed elements
(https://github.com/catppuccin/theme.park/issues/13 mentioned it, however since catppuccin is a community-theme, I've recreated the images with dracula, just in case)

This issue realtes to the unthemed search bar (and the borders of the searchbar and the icon next to it whose purpose I currently don't know):
![qbit_search](https://github.com/user-attachments/assets/b85c9aaa-5004-4396-9769-07b43fd85cc3)

And the modals are unthemed at the botton:
![qbit_modal](https://github.com/user-attachments/assets/f2b0442f-6d7c-45d6-a62f-f88d6007331a)

With the changes I've done the searchbar is now themed:
![qbit_search_fix](https://github.com/user-attachments/assets/2596f213-62fe-4bef-b5b8-275c9460543d)

As well as the modal:
![qbit_modal_fix](https://github.com/user-attachments/assets/c9cbe72d-4888-4656-bed2-a38504b09ed5)

NOTE: The I've used `var(--drop-down-menu-bg)` instead of `var(--modal-bg-color)` since qbit just didn't want to apply the css with themes that don't have a simple hex code as their definition for modal-bg-color, like hotline, if I try to set it there, it just won't apply it

(Unrelated to this pr, but on the modal image, is there a reason why the category input is hardcoded to #fff and not var(--transparency-dark-25) like the others?, I know it looks a bit darker than the rest for this dropdown menu but I think this may look better overall?)
<!--- Describe your changes in detail -->
<!--- Add before and after screenshots of your changes -->

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
It fixes unthemed elements in qbittorrent

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've tested this by importing
`@import url("https://theme-park.dev/css/theme-options/dracula.css");`, as well as the contents of https://github.com/themepark-dev/theme.park/blob/develop/css/base/qbittorrent/qbittorrent-base.css in stylus, that styled my local my qbit web and added my changes to it.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
https://github.com/catppuccin/theme.park/issues/13