### PR TITLE
Fix Seerr background selector after update

### DIFF
--- a/css/base/overseerr/overseerr-base.css
+++ b/css/base/overseerr/overseerr-base.css
@@ -222,7 +222,7 @@ select:focus {
 
 
 /* BG STUFF */
-#__next>div,
+#__next>div:first-of-type,
 body {
     background: var(--main-bg-color);
     background-repeat: repeat, no-repeat;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[themeparkurl]: https://theme-park.dev
[![theme-park.dev](https://raw.githubusercontent.com/GilbN/theme.park/master/banners/tp_banner.png)][themeparkurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality/styling please look at making an addon instead. https://docs.theme-park.dev/themes/addons/sonarr/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->

------------------------------

 - [x] I have read the [contributing](https://github.com/GilbN/theme.park/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

- PR's are done against the develop branch.
------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Bug fixes

- When submitting bugfixes please show a before and after screenshot of the fix, and a description of what the fix does.

## Description:
Fixes the selectors for setting the background color in (Over)seerr base.

## Benefits of this PR and context:
Currently:
<img width="2940" height="1690" alt="CleanShot 2026-06-18 at 15 56 36@2x" src="https://github.com/user-attachments/assets/61d4ab1a-5bab-4ab5-8b0f-f7e72d327f11" />

Fix:
<img width="2940" height="1690" alt="CleanShot 2026-06-18 at 15 55 59@2x" src="https://github.com/user-attachments/assets/5781f3df-e390-40e6-b136-6cefc2aedd1c" />

## How Has This Been Tested?
Stylus extension

## Source / References:
Seerr PR that caused this (new div from `react-hot-toast`): https://github.com/seerr-team/seerr/pull/3004