### PR TITLE
Bump base image to Alpine 3.24 for amd64 and arm64

### DIFF
--- a/docker/root/defaults/nginx/site-confs/default.conf
+++ b/docker/root/defaults/nginx/site-confs/default.conf
@@ -2,8 +2,9 @@ server {
     listen 80 default_server;
     listen [::]:80 default_server;
 
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
 
     server_name _;
 

--- a/linux-amd64.Dockerfile
+++ b/linux-amd64.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-alpine-nginx:3.19
+FROM ghcr.io/linuxserver/baseimage-alpine-nginx:3.24
 
 # set version label
 ARG BUILD_DATE

--- a/linux-arm64.Dockerfile
+++ b/linux-arm64.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-alpine-nginx:arm64v8-3.19
+FROM ghcr.io/linuxserver/baseimage-alpine-nginx:arm64v8-3.24
 
 # set version label
 ARG BUILD_DATE


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[themeparkurl]: https://theme-park.dev
[![theme-park.dev](https://raw.githubusercontent.com/GilbN/theme.park/master/banners/tp_banner.png)][themeparkurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality/styling please look at making an addon instead. https://docs.theme-park.dev/themes/addons/sonarr/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->

------------------------------

 - [x] I have read the [contributing](https://github.com/GilbN/theme.park/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

- PR's are done against the develop branch.
------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Bump the base image version to alpine 3.24 for amd64 and arm64

## Benefits of this PR and context:
Support for the Alpine 3.19 base image ended eight months ago. Updating to Alpine 3.24 ensures continued access to security fixes.

This MR also updates the nginx configuration to address a deprecation warning. However, the armv7 image still uses an older nginx version that does not support this change. Since [the armv7 images are deprecated](https://www.linuxserver.io/blog/a-farewell-to-arm-hf) and will no longer receive new base image versions, I would appreciate maintainer feedback on how armv7 should be handled going forward.

- Keep the old configuration and ignore the warning.
- Remove the armv7 builds.
- Add a legacy nginx configuration specifically for the armv7 image.

<img width="747" height="431" alt="Screenshot 2026-07-20 181324" src="https://github.com/user-attachments/assets/8994fa95-782a-4b73-a817-21d9bd541cc7" />

[Link](https://endoflife.date/alpine-linux)

<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I built the new image on my amd64 machine, checked the logs, and tested it with Sonarr.