### PR TITLE
Remove dhparams as it is no longer needed

### DIFF
--- a/docker/root/defaults/nginx/ssl.conf
+++ b/docker/root/defaults/nginx/ssl.conf
@@ -10,9 +10,6 @@ ssl_session_timeout 1d;
 ssl_session_cache shared:MozSSL:10m; # about 40000 sessions
 ssl_session_tickets off;
 
-# curl https://ssl-config.mozilla.org/ffdhe2048.txt > /path/to/dhparam
-ssl_dhparam /config/nginx/dhparams.pem;
-
 # intermediate configuration
 ssl_protocols TLSv1.2 TLSv1.3;
 ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[themeparkurl]: https://theme-park.dev
[![theme-park.dev](https://raw.githubusercontent.com/GilbN/theme.park/master/banners/tp_banner.png)][themeparkurl]

<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality/styling please look at making an addon instead. https://docs.theme-park.dev/themes/addons/sonarr/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->

------------------------------

 - [x] I have read the [contributing](https://github.com/GilbN/theme.park/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

- PR's are done against the develop branch.
------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Bug fixes

- When submitting bugfixes please show a before and after screenshot of the fix, and a description of what the fix does.

## Description:
<!--- Describe your changes in detail -->
<!--- Add before and after screenshots of your changes -->

In the latest nginx image from LSIO, they removed the generation and check of the dhparams.pem file here: https://github.com/linuxserver/docker-baseimage-alpine-nginx/commit/a58e188d1078fd64e0b0757379eb3c3db962fa71 . By updating the base image, this file is no longer generated, causing this ssl config to fail on startup. Removing it to match the changes to the image.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Removed the dhparams line from ssl.conf

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally, image would not run prior to this change, now it starts up.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
https://github.com/linuxserver/docker-baseimage-alpine-nginx/commit/a58e188d1078fd64e0b0757379eb3c3db962fa71